### PR TITLE
add riscv64 linux to release build target list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
             x86_64-macos
             x86_64-linux-musl
             aarch64-linux-musl
+            riscv64-linux-musl
             x86_64-windows-gnu
           )
 


### PR DESCRIPTION
Great project. I have some riscv64 hardware (k3 SOC adhering to rva23). zig cross compilation seems to be working fine for it, and I can run ziggity on that hardware. This PR just adds it to the list of release targets if you don't mind.