### PR TITLE
Fix TUI resize for WezTerm

### DIFF
--- a/src/tui.zig
+++ b/src/tui.zig
@@ -397,6 +397,7 @@ pub fn run(init: std.process.Init, app: *app_mod.App) !void {
 
     var loop: vaxis.Loop(Event) = .init(io, &tty, &vx);
     try loop.start();
+    try loop.installResizeHandler();
     defer loop.stop();
 
     var refresh_ticker: RefreshTicker = .{ .io = io, .loop = &loop, .app = app };


### PR DESCRIPTION
Terminal resize worked in Kitty and Ghostty but not in WezTerm, Alacritty and Terminal.app. Vaxis supports two resize notification paths:

- In-band (Kitty, Ghostty) - the terminal sends new dimensions as escape sequences in stdin. Vaxis picks these up in the tty read thread and posts .winsize events directly so no signal handler needed
- SIGWINCH (WezTerm and some other terminals) - the kernel delivers a signal and vaxis invokes registered callbacks. Without installResizeHandler() callbacks array was empty

For fix it - just add loop.installResizeHandler() after loop.start()