### PR TITLE
docs: document the branch_sort_order setting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,6 +70,7 @@ show_file_tree = false
 # activates when the tool is installed and authenticated and the remote is
 # GitHub or GitLab, and stays silent otherwise. Set false to disable it.
 pr_status = true
+branch_sort_order = date           # Local Branches panel ordering: date (default) | recency | alphabetical
 
 # Editor for `e`. With nothing set, auto detected from git core.editor, then
 # $GIT_EDITOR, $VISUAL, $EDITOR, falling back to vim. See "Editor" below.


### PR DESCRIPTION
The "All settings (annotated `.ini`)" block in `docs/configuration.md` documents every setting, but `branch_sort_order` is missing from it.

It is a real, parsed setting:

- `src/config.zig:327`: `branch_sort_order: model.BranchSortOrder = .date`
- parsed in `applyBytes` at `src/config.zig:445`
- `src/model.zig`: `BranchSortOrder = enum { date, recency, alphabetical }`
- covered by a parser test (`branch_sort_order = recency`)

This adds it next to `pr_status` (the other Branches panel setting), matching the annotated `.ini` style, using the wording from the field own doc comment.
