### PR TITLE
Add configurable fetch mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,6 +103,11 @@ commit_graph = on                  # on (default) | focused | off
 # HEAD node stands out among the other refs). `a` toggles it live inside the
 # overlay; this just sets which scope it opens with.
 commit_graph_scope = current       # current (default) | all
+# How `f` (fetch) behaves. `git` (default) runs `git fetch`, which follows your own
+# git `fetch.prune` config (set `git config fetch.prune true` to fetch with prune).
+# `on` forces fetch with prune (using `fetch --prune`).
+# `off` forces fetch without prune (using `-c fetch.prune=false fetch`).
+fetch_prune_mode = git             # git (default: follow git's fetch.prune) | on | off
 # How `p` (pull) behaves. `git` (default) runs `git pull`, which follows your own
 # git `pull.rebase` config (set `git config pull.rebase true` for rebase pulls).
 # `menu` opens a menu to pick merge, rebase, or fast-forward-only — but only when

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -130,9 +130,12 @@ the written reference. Every binding is remappable, see
   (ziggity re-reads the file when the editor closes and stages it automatically
   once the markers are gone), and **mark as resolved**, which stages a file you
   already fixed by hand (both refuse while conflict markers remain)
-- `f` / `p` / `P`: fetch / pull / push. `pull` follows your git `pull.rebase`
-  config by default; set `pull_mode = menu` to pick merge/rebase/fast-forward
-  when a pull has local commits to integrate (see [Configuration](configuration.md))
+- `f` / `p` / `P`: fetch / pull / push. `fetch` follows your git `fetch.prune`
+  config by default; set `fetch_prune_mode = on` to force fetch with prune; set
+  `fetch_prune_mode = off` to force fetch without prune; `pull` follows your git
+  `pull.rebase` config by default; set `pull_mode = menu` to pick
+  merge/rebase/fast-forward when a pull has local commits to integrate
+  (see [Configuration](configuration.md))
 - `esc`: step back one level (deselect, clear a filter, exit diffing, cancel
   a prompt, leave a panel); never quits, only `q` does
 

--- a/src/app.zig
+++ b/src/app.zig
@@ -294,7 +294,12 @@ fn freeRetryAction(action: RetryAction) void {
 
 /// Network operations that run off the UI loop so they don't freeze it.
 pub const AsyncOp = enum {
+    /// `git fetch`, honouring the user's `fetch.prune` config (`fetch_prune_mode = git`).
     fetch,
+    /// Force prune by `git fetch --prune`
+    fetch_prune,
+    /// Force without prune, by `git -c "fetch.prune=false" fetch`
+    fetch_no_prune,
     /// `git pull`, honouring the user's `pull.rebase` config (`pull_mode = git`).
     pull,
     /// The explicit pull variants offered by `pull_mode = menu`: force a merge
@@ -332,7 +337,7 @@ pub const AsyncOp = enum {
 
     pub fn label(self: AsyncOp) []const u8 {
         return switch (self) {
-            .fetch, .fetch_remote => "fetch",
+            .fetch, .fetch_prune, .fetch_no_prune, .fetch_remote => "fetch",
             .pull, .pull_merge, .pull_rebase, .pull_ff_only => "pull",
             .push, .push_force, .push_force_plain, .push_set_upstream, .push_tag => "push",
         };
@@ -341,6 +346,8 @@ pub const AsyncOp = enum {
     pub fn gerund(self: AsyncOp) []const u8 {
         return switch (self) {
             .fetch, .fetch_remote => "fetching",
+            .fetch_prune => "fetching with prune",
+            .fetch_no_prune => "fetching without prune",
             .pull, .pull_merge, .pull_rebase, .pull_ff_only => "pulling",
             .push, .push_set_upstream, .push_tag => "pushing",
             .push_force => "force push with lease",
@@ -358,6 +365,10 @@ pub const AsyncOp = enum {
             // refs without asking. A branch surfaces as "(upstream gone)" once a
             // prune happens — i.e. exactly when git itself would consider it gone.
             .fetch => &.{ "fetch", "--all", "--no-write-fetch-head" },
+            // Force fetch with --prune (overriding possible user's `fetch.prune` git config)
+            .fetch_prune => &.{ "fetch", "--all", "--no-write-fetch-head", "--prune" },
+            // Force fetch without prune (overriding possible user's `fetch.prune` git config)
+            .fetch_no_prune => &.{ "-c", "fetch.prune=false", "fetch", "--all", "--no-write-fetch-head" },
             // The remote name is appended by the worker (from `fetch_remote_name`).
             .fetch_remote => &.{"fetch"},
             .pull => &.{ "pull", "--no-edit" },
@@ -3766,7 +3777,15 @@ pub const App = struct {
                 self.refreshViews(Refresh.all);
                 try self.setMessage("refreshed", .{});
             },
-            .fetch => try self.requestAsync(.fetch),
+            .fetch => {
+                if (self.config.fetch_prune_mode == .on) {
+                    try self.requestAsync(.fetch_prune);
+                } else if (self.config.fetch_prune_mode == .off) {
+                    try self.requestAsync(.fetch_no_prune);
+                } else {
+                    try self.requestAsync(.fetch);
+                }
+            },
             .pull => try self.startPull(),
             .push => try self.startPush(),
             .move_up => if (self.staging_active) staging_mod.moveStagingCursor(self, -1) else try self.moveUp(),

--- a/src/config.zig
+++ b/src/config.zig
@@ -351,6 +351,10 @@ pub const Config = struct {
     /// the current branch and its upstream) or `all` (every branch). `a` toggles
     /// it live; this sets which scope it opens with.
     commit_graph_scope: model.CommitGraphScope = .current,
+    /// How `fetch` (`f`) prune behaves: `git` (the default) runs `git fetch`, honouring
+    /// git's own `fetch.prune` config; `on` forces `--prune` option; `off` forces
+    /// never use prune by running `git -c "fetch.prune=false" fetch`.
+    fetch_prune_mode: model.FetchPruneMode = .git,
     /// How `pull` behaves: `git` (default) runs `git pull`, honouring your git
     /// `pull.rebase` config; `menu` opens a menu to pick merge / rebase /
     /// fast-forward-only for each pull.
@@ -508,6 +512,11 @@ pub const Config = struct {
         }
         if (std.mem.eql(u8, key, "commit_graph_scope")) {
             if (std.meta.stringToEnum(model.CommitGraphScope, value)) |v| self.commit_graph_scope = v;
+            return;
+        }
+        if (std.mem.eql(u8, key, "fetch_prune_mode")) {
+            if (std.meta.stringToEnum(model.FetchPruneMode, value)) |v| self.fetch_prune_mode = v;
+            std.debug.print("fetch_prune_mode: {}", .{self.fetch_prune_mode});
             return;
         }
         if (std.mem.eql(u8, key, "pull_mode")) {

--- a/src/model.zig
+++ b/src/model.zig
@@ -19,6 +19,11 @@ pub const CommitGraphMode = enum { off, focused, on };
 /// live; this is only the initial scope.
 pub const CommitGraphScope = enum { current, all };
 
+/// How `fetch` (`f`) prune behaves: `git` (the default) runs `git fetch`, honouring
+/// git's own `fetch.prune` config; `on` forces `--prune` option; `off` forces
+/// never use prune by running `git -c "fetch.prune=false" fetch`.
+pub const FetchPruneMode = enum { git, on, off };
+
 /// How `pull` (`p`) behaves: `git` (the default) runs `git pull`, honouring
 /// git's own `pull.rebase` config; `menu` opens a menu to choose merge / rebase
 /// / fast-forward-only for each pull.


### PR DESCRIPTION
This is a try to solve #36 based on `pull_mode` implemented before in https://github.com/simoarpe/ziggity/commit/0d4e424d75ce5e6aa86b5c2fbc477d2320413d41

Fetch prune defaults to matching Git's configured behavior
which can be set by `fetch.prune` option in config.

Now we have a configuration option which can override
this behavior by setting `fetch_prune_mode` to:
`git` (or any other config value) - get setting from git config
`on` - force fetch with prune (using `--prune`)
`off` - force fetch without prune (using `-c fetch.prune=false`)